### PR TITLE
infra: Render service skeleton

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,7 @@
+- Base path: https://thebiaslens.onrender.com
+- Endpoints to implement today:
+  - GET /health → returns { status: "ok" }
+  - GET /search?q=… → returns a list of normalized articles with fields:
+    title, source, publishedAt, url, and either body or extractStatus
+  - POST /extract with { url } → returns { body, extractStatus }
+- Notes: rate limits and caching will be added later.


### PR DESCRIPTION
Purpose: create Render Web Service entry, set env-vars, and document backend contract.
Acceptance:

-     Render Web Service exists, rooted at api, Auto-deploy is Manual.
-     Health Check Path is /health.
-     Env-vars placeholders created on Render.
-     api/README.md documents /health, /search, /extract shapes.