### PR TITLE
Sprint2.4 bisa UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ TheBiasLens consists of two main components:
 - **News Search**: Search articles from multiple news providers (currently NewsAPI)
 - **Article Extraction**: Extract full article content from URLs using trafilatura
 - **Text Summarization**: Generate lead-3 summaries from extracted content
-- **Combined Analysis**: Single-endpoint analysis combining extraction and summarization
+- **Bias Analysis UI**: Visual political bias meter with Left/Neutral/Right labels
+- **Combined Analysis**: Single-endpoint analysis combining extraction, summarization, and bias detection
 - **Responsive Design**: Mobile-first UI with Material-UI components
 - **Search to Analysis Flow**: Click "Analyze" buttons in search results to automatically extract and summarize articles
 - **Real-time Updates**: Live search results with loading states and error handling
+- **Unified Analysis UI**: Integrated card layout combining metadata, bias analysis, and summary
+- **Copy Functionality**: One-click copy for summaries with visual feedback
 
 ### Planned Features 🚧
 
-- **Bias Analysis**: Left/Center/Right political framing detection
+- **Bias ML Model**: Implementation of the political framing detection algorithm
 - **Fact-check Integration**: Surface fact-check snippets with citations
 - **User Preferences**: Saved searches and bookmarks
 - **Historical Analysis**: Track bias trends over time
@@ -82,14 +85,17 @@ thebiaslens/
 - Article extraction with trafilatura integration
 - Lead-3 text summarization
 - Combined analysis endpoint
+- Bias schema and UI implementation
+- Unified analysis card with integrated components
 - Responsive web interface with search and analysis
 - Navigation flow from search results to analysis page
 - URL parameter handling for direct analysis links
+- Copy feedback and improved user interactions
 - Mock data fallback for development
 
 🚧 **In Progress**:
 
-- Bias detection algorithms
+- Bias detection ML model integration
 - Fact-checking integration
 - Enhanced UI/UX improvements
 

--- a/api/README.md
+++ b/api/README.md
@@ -283,3 +283,14 @@ api/
 - **Rate Limiting**: Request throttling and quotas
 - **Authentication**: API key management for different usage tiers
 - **Webhooks**: Real-time notifications for analysis completion
+
+## Bias Analysis
+
+### Bias Labels and Scoring
+
+- **Three Labels Only**: "Left", "Neutral", "Right"
+- **Score Range**: -1 to 1 (where -1 = left, 0 = neutral, +1 = right)
+- **Suggested Thresholds for Later**:
+  - Left: score <= -0.2
+  - Neutral: -0.2 < score < 0.2
+  - Right: score >= 0.2

--- a/api/README.md
+++ b/api/README.md
@@ -9,7 +9,8 @@ FastAPI backend for news search, article extraction, and content analysis with c
 - **News Search**: `/search` endpoint with pagination support and provider abstraction
 - **Article Extraction**: `GET /extract?url=` — fetch and extract full article text with trafilatura
 - **Text Summarization**: `POST /summarize` — create lead-3 summaries from article text
-- **Combined Analysis**: `GET /analyze/url` — extract and summarize in a single request
+- **Combined Analysis**: `GET /analyze/url` — extract, summarize, and perform bias analysis in a single request
+- **Bias Analysis**: Schema support for Left/Neutral/Right political framing with confidence scores
 - **Health Check**: `/health` — service status and version information
 
 ### Technical Features
@@ -214,7 +215,7 @@ GET /analyze/url?url=https://example.com/news-article
 
 ```json
 {
-  "extractResult": {
+  "extract": {
     "url": "https://example.com/news-article",
     "headline": "Article Headline",
     "source": "Source Name",
@@ -222,11 +223,17 @@ GET /analyze/url?url=https://example.com/news-article
     "wordCount": 1250,
     "extractStatus": "extracted"
   },
-  "summarizeResult": {
+  "summary": {
     "sentences": ["Key sentence 1.", "Key sentence 2.", "Key sentence 3."],
     "joined": "Key sentence 1. Key sentence 2. Key sentence 3.",
     "charCount": 156,
     "wordCount": 28
+  },
+  "bias": {
+    "label": "Neutral",
+    "confidence": 0.82,
+    "score": 0.05,
+    "calibrationVersion": "v1"
   }
 }
 ```
@@ -273,11 +280,17 @@ api/
 3. **Testing**: Use mock mode by omitting API keys
 4. **Production**: Configure all environment variables and use production ASGI server
 
-## Future Enhancements
+## Current Features and Future Enhancements
+
+✅ **Implemented Features**:
+
+- **Bias Analysis Schema**: Complete Pydantic models for bias detection results
+- **Combined Analysis Endpoint**: Ready for ML model integration
+- **Score Standardization**: Normalized -1 to 1 scoring system
 
 🚧 **Planned Features**:
 
-- **Bias Detection**: ML-powered political framing analysis
+- **Bias ML Model**: Political framing analysis model implementation
 - **Fact-Checking**: Integration with fact-checking services
 - **Advanced Caching**: Redis/Upstash for distributed caching
 - **Rate Limiting**: Request throttling and quotas
@@ -288,9 +301,11 @@ api/
 
 ### Bias Labels and Scoring
 
-- **Three Labels Only**: "Left", "Neutral", "Right"
+- **Three Labels Only**: "Left", "Neutral", "Right" (implemented as enum)
 - **Score Range**: -1 to 1 (where -1 = left, 0 = neutral, +1 = right)
-- **Suggested Thresholds for Later**:
+- **Confidence Level**: 0 to 1 score indicating certainty of classification
+- **Calibration Versioning**: Support for model version tracking
+- **Suggested Thresholds**:
   - Left: score <= -0.2
   - Neutral: -0.2 < score < 0.2
   - Right: score >= 0.2

--- a/api/main.py
+++ b/api/main.py
@@ -79,7 +79,7 @@ def search(
         # TODO: add provider switch if we add GNews later
         return search_news(q, page=cursor, page_size=pageSize)
     else:
-        # Fallback to mock data (unchanged from original implementation)
+        # Fallback to mock data 
         query_lower = q.lower()
         filtered_articles = [
             article for article in MOCK_ARTICLES
@@ -217,5 +217,6 @@ async def analyze_url(url: str = Query(..., description="URL of the article to a
     # Return combined result
     return AnalyzeResult(
         extract=extract_result,
-        summary=summary_result
+        summary=summary_result,
+        bias=None
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,6 +1,22 @@
 from pydantic import BaseModel
 from typing import Optional, Literal, List
 from datetime import datetime
+from enum import Enum
+
+
+class BiasLabel(str, Enum):
+    """Political bias labels."""
+    LEFT = "Left"
+    NEUTRAL = "Neutral"
+    RIGHT = "Right"
+
+
+class BiasResult(BaseModel):
+    """Bias analysis result."""
+    label: BiasLabel
+    confidence: float  # [0..1]
+    score: float  # [-1..1] where -1 left, 0 neutral, +1 right
+    calibrationVersion: str = "v1"
 
 
 class ArticleStub(BaseModel):
@@ -37,3 +53,4 @@ class AnalyzeResult(BaseModel):
     """Combined extraction and summary result."""
     extract: ExtractResult
     summary: Optional[SummaryResult] = None
+    bias: Optional[BiasResult] = None

--- a/api/services/extract.py
+++ b/api/services/extract.py
@@ -182,7 +182,7 @@ def _normalize_author(val: Optional[str]) -> Optional[str]:
     if not v:
         return None
     # If it's a URL to a profile, try to convert the slug to title case
-    if v.startswith('http'):  # e.g., https://www.theguardian.com/profile/coral-murphy-marcos
+    if v.startswith('http'):  
         try:
             from urllib.parse import urlparse
             path = urlparse(v).path.strip('/')
@@ -192,7 +192,7 @@ def _normalize_author(val: Optional[str]) -> Optional[str]:
                 return ' '.join(w.capitalize() for w in name.split())
         except Exception:
             pass
-        return None  # avoid showing raw URL as author
+        return None  
     # Drop emails to just the local-part
     if '@' in v and ' ' not in v:
         v = v.split('@')[0].replace('.', ' ')
@@ -267,7 +267,7 @@ async def extract_article(url: str) -> Tuple[Optional[str], Optional[str], int, 
     # Fallback: try common meta tags for author and date
     try:
         def _find_meta_content(names: Tuple[str, ...]) -> Optional[str]:
-            # Matches e.g., <meta name="author" content="..."> or <meta property='article:published_time' content='...'>
+           
             pattern = r"<meta[^>]+(?:name|property)=[\'\"](?:" + "|".join(map(re.escape, names)) + r")[\'\"][^>]*content=[\'\"](.*?)[\'\"][^>]*>"
             m = re.search(pattern, html, re.IGNORECASE | re.DOTALL)
             return unescape(m.group(1).strip()) if m else None

--- a/app/thebiaslens/README.md
+++ b/app/thebiaslens/README.md
@@ -10,6 +10,8 @@ React + TypeScript frontend for news search and content analysis with responsive
 - **Article Analysis**: Extract and summarize articles with a single click from search results
 - **Content Extraction**: Full article text extraction with metadata display
 - **Text Summarization**: AI-powered lead-3 summaries with copy-to-clipboard functionality
+- **Bias Visualization**: Interactive political bias meter with Left/Neutral/Right indicators
+- **Unified Analysis UI**: Combined card layout for metadata, bias, and summary analysis
 - **Responsive Design**: Mobile-first UI optimized for all screen sizes
 - **Navigation Flow**: Seamless transition from search results to detailed analysis
 
@@ -17,6 +19,8 @@ React + TypeScript frontend for news search and content analysis with responsive
 
 - **Loading States**: Skeleton screens and loading indicators for better perceived performance
 - **Error Handling**: User-friendly error messages and fallbacks
+- **Copy Feedback**: Visual confirmation when text is copied to clipboard
+- **Unified Interface**: Seamless single-card experience for article analysis
 - **URL Parameter Support**: Direct links to analysis pages with pre-filled URLs
 - **Progressive Enhancement**: Works with or without JavaScript enabled
 - **Accessibility**: ARIA labels, keyboard navigation, and screen reader support
@@ -43,13 +47,17 @@ src/
 │       ├── UrlForm.tsx     # URL input form for analysis
 │       ├── ExtractResultCard.tsx  # Article content display
 │       ├── ArticleMetadata.tsx    # Article title, source, metadata
-│       ├── SummarySection.tsx     # Summary display and controls
-│       └── ArticleTextSection.tsx # Full text toggle and display
+│       ├── BiasMeter.tsx    # Political bias visualization
+│       ├── BiasLegend.tsx   # Explanatory modal for bias analysis
+│       ├── BiasAndSummarySection.tsx # Combined bias and summary display
+│       ├── ArticleTextCard.tsx   # Full article text display
+│       └── InputTypeSelector.tsx # URL/Text/PDF selector (URL implemented)
 ├── hooks/                  # Custom React hooks
 │   ├── useSearch.ts        # Single-page search hook
 │   ├── useSearchPaged.ts   # Paginated search hook
 │   ├── useExtract.ts       # Article extraction hook
 │   ├── useSummarize.ts     # Text summarization hook
+│   ├── useAnalyze.ts       # Combined extraction, summary, and bias analysis
 │   └── useTheme.ts         # Theme management
 ├── routes/                 # Page components
 │   ├── Search.tsx          # Main search page
@@ -126,15 +134,18 @@ REACT_APP_API_BASE_URL=http://127.0.0.1:8000
 - Search interface with real-time results
 - Article content extraction from URLs
 - AI-powered text summarization
+- Political bias visualization UI
+- Unified analysis card interface
 - Responsive design and navigation
 - Error handling and loading states
 - API integration with fallbacks
 - URL parameter handling for direct analysis
-- Copy-to-clipboard functionality
+- Copy-to-clipboard functionality with feedback
+- Accessibility improvements and ARIA support
 
 🚧 **Planned**:
 
-- Bias analysis visualization
+- Bias ML model integration
 - Fact-check integration
 - User preferences and history
 - Saved searches and bookmarks

--- a/app/thebiaslens/src/components/ResultList.tsx
+++ b/app/thebiaslens/src/components/ResultList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Button, Box, IconButton, Card, CardContent } from '@mui/material';
+import { Typography, Button, Box, IconButton, Card, CardContent, Chip } from '@mui/material';
 import { Analytics, OpenInNew } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { ArticleStub } from '../types/api';
@@ -53,9 +53,24 @@ const ResultItem: React.FC<ResultItemProps> = ({ item }) => {
         </Typography>
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <Typography variant="caption" color="text.secondary">
-            {item.publishedAt && new Date(item.publishedAt).toLocaleDateString()}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              {item.publishedAt && new Date(item.publishedAt).toLocaleDateString()}
+            </Typography>
+            {/* Bias pill - pending until classification is implemented */}
+            <Chip
+              label="Bias: pending"
+              size="small"
+              variant="outlined"
+              sx={{
+                fontSize: '0.6rem',
+                height: 20,
+                color: 'text.secondary',
+                borderColor: 'grey.300',
+                backgroundColor: 'grey.50',
+              }}
+            />
+          </Box>
           <Typography variant="caption" color="text.secondary">
             {item.source}
           </Typography>

--- a/app/thebiaslens/src/components/analyze/ArticleMetadata.tsx
+++ b/app/thebiaslens/src/components/analyze/ArticleMetadata.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Stack, Typography, Chip } from '@mui/material';
+import { Stack, Typography, Chip } from '@mui/material';
 import { Public } from '@mui/icons-material';
 import { ExtractResult } from '../../types/api';
 
@@ -19,8 +19,8 @@ const ArticleMetadata: React.FC<ArticleMetadataProps> = ({ result, formatDate })
           gutterBottom
           sx={{
             fontWeight: 600,
-            lineHeight: 1.3,
-            mb: 3,
+            lineHeight: 1.1,
+            mb: 1,
             color: 'text.primary',
           }}
         >
@@ -31,9 +31,21 @@ const ArticleMetadata: React.FC<ArticleMetadataProps> = ({ result, formatDate })
           Title not available
         </Typography>
       )}
-
-      {/* Source/Website Name - Second */}
-      <Box sx={{ mb: 3 }}>
+      {/* Source and Metadata Row - Combined */}
+      <Stack
+        direction="row"
+        spacing={2}
+        alignItems="center"
+        sx={{
+          mb: 1,
+          py: 2,
+          backgroundColor: 'grey.50',
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: 'grey.200',
+        }}
+      >
+        {/* Source chip on the left */}
         <Chip
           icon={<Public />}
           label={result.source}
@@ -44,22 +56,8 @@ const ArticleMetadata: React.FC<ArticleMetadataProps> = ({ result, formatDate })
             fontWeight: 600,
           }}
         />
-      </Box>
 
-      {/* Metadata Row - Third */}
-      <Stack
-        direction="row"
-        spacing={2}
-        alignItems="center"
-        sx={{
-          mb: 3,
-          p: 2,
-          backgroundColor: 'grey.50',
-          borderRadius: 1,
-          border: '1px solid',
-          borderColor: 'grey.200',
-        }}
-      >
+        {/* Metadata items on the right */}
         {result.publishedAt && (
           <Typography variant="body2" color="text.secondary">
             📅 {formatDate(result.publishedAt)}

--- a/app/thebiaslens/src/components/analyze/ArticleTextCard.tsx
+++ b/app/thebiaslens/src/components/analyze/ArticleTextCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Card, CardContent } from '@mui/material';
+import { ExtractResult } from '../../types/api';
+import ArticleTextSection from './ArticleTextSection';
+
+interface ArticleTextCardProps {
+  result: ExtractResult;
+  showFullText: boolean;
+  onToggleText: () => void;
+  getPreviewText: (text: string, maxLength?: number) => string;
+}
+
+const ArticleTextCard: React.FC<ArticleTextCardProps> = ({
+  result,
+  showFullText,
+  onToggleText,
+  getPreviewText,
+}) => {
+  return (
+    <Card sx={{ mt: 3, boxShadow: 2 }}>
+      <CardContent sx={{ p: 3 }}>
+        <ArticleTextSection
+          result={result}
+          showFullText={showFullText}
+          onToggleText={onToggleText}
+          getPreviewText={getPreviewText}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ArticleTextCard;

--- a/app/thebiaslens/src/components/analyze/BiasAndSummarySection.tsx
+++ b/app/thebiaslens/src/components/analyze/BiasAndSummarySection.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+import { Refresh, ContentCopy } from '@mui/icons-material';
+import { BiasResult, SummaryResult } from '../../types/api';
+import { BiasMeter } from './BiasMeter';
+import { BiasLegend } from './BiasLegend';
+
+interface BiasAndSummarySectionProps {
+  bias: BiasResult | null;
+  result: { body?: string; extractStatus: string };
+  summaryResult?: SummaryResult;
+  isSummarizing: boolean;
+  summaryError: any;
+  onRegenerate: () => void;
+}
+
+export const BiasAndSummarySection: React.FC<BiasAndSummarySectionProps> = ({
+  bias,
+  result,
+  summaryResult,
+  isSummarizing,
+  summaryError,
+  onRegenerate,
+}) => {
+  const [showLegend, setShowLegend] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(false);
+
+  const handleCopyText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000); // Reset after 2 seconds
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <>
+      <Box>
+        {/* Section Header */}
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+          <Typography variant="h5" component="h2" sx={{ fontWeight: 600 }}>
+            Bias and Summary
+          </Typography>
+          <button
+            onClick={() => setShowLegend(true)}
+            className="text-gray-400 hover:text-gray-600 w-5 h-5 flex items-center justify-center rounded-full border border-gray-300 hover:border-gray-400 transition-colors"
+            aria-label="Show bias analysis legend"
+            title="Learn about bias analysis"
+          >
+            <span className="text-xs font-medium">?</span>
+          </button>
+        </Box>
+
+        {/* Bias Meter */}
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="h6" component="h3" sx={{ fontWeight: 600, mb: 1 }}>
+            Bias
+          </Typography>
+          <BiasMeter bias={bias} />
+        </Box>
+
+        {/* Summary Section */}
+        {result.body && result.extractStatus === 'extracted' && (
+          <Box>
+            {/* Show skeleton while summarizing */}
+            {isSummarizing && (
+              <Box sx={{ mb: 3 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <Typography variant="body1">Generating Summary</Typography>
+                  <CircularProgress size={20} sx={{ ml: 2 }} />
+                </Box>
+                <Box
+                  sx={{
+                    height: 100,
+                    bgcolor: 'grey.100',
+                    borderRadius: 1,
+                    border: '1px solid',
+                    borderColor: 'grey.300',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              </Box>
+            )}
+
+            {/* Show error if summarization failed */}
+            {summaryError && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                <Box>
+                  Summary generation failed. Please try again.
+                  <Button
+                    size="small"
+                    startIcon={<Refresh />}
+                    onClick={onRegenerate}
+                    sx={{ ml: 2 }}
+                  >
+                    Retry
+                  </Button>
+                </Box>
+              </Alert>
+            )}
+
+            {/* Show summary if available */}
+            {summaryResult && !isSummarizing && (
+              <Box sx={{ mb: 2 }}>
+                <Box
+                  sx={{
+                    p: 0,
+                    borderRadius: 0,
+                    border: 'none',
+                  }}
+                >
+                  <List sx={{ p: 0 }}>
+                    {summaryResult.sentences.map((sentence, index) => (
+                      <ListItem key={index} sx={{ px: 0, py: 0.5 }}>
+                        <ListItemText
+                          primary={sentence}
+                          primaryTypographyProps={{
+                            variant: 'body1',
+                            sx: { lineHeight: 1.6 },
+                          }}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      mt: 1.5,
+                      pt: 1.5,
+                      borderTop: '1px solid',
+                      borderColor: 'grey.200',
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {summaryResult.sentences.length} sentences • {summaryResult.wordCount} words •{' '}
+                      {summaryResult.charCount} characters
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                      <Button
+                        size="small"
+                        startIcon={<ContentCopy />}
+                        onClick={() => handleCopyText(summaryResult.joined)}
+                        variant="outlined"
+                        color={copySuccess ? 'success' : 'primary'}
+                      >
+                        {copySuccess ? 'Copied!' : 'Copy'}
+                      </Button>
+                      <Button
+                        size="small"
+                        startIcon={<Refresh />}
+                        onClick={onRegenerate}
+                        variant="outlined"
+                      >
+                        Regenerate
+                      </Button>
+                    </Box>
+                  </Box>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {/* Legend modal */}
+      <BiasLegend isOpen={showLegend} onClose={() => setShowLegend(false)} />
+    </>
+  );
+};

--- a/app/thebiaslens/src/components/analyze/BiasLegend.tsx
+++ b/app/thebiaslens/src/components/analyze/BiasLegend.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+interface BiasLegendProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const BiasLegend: React.FC<BiasLegendProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-md mx-4 shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">Bias Analysis Legend</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl"
+            aria-label="Close legend"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {/* Left bias */}
+          <div className="flex items-start space-x-3">
+            <div className="w-2 h-2 bg-blue-600 rounded-full mt-2 flex-shrink-0" />
+            <div>
+              <div className="font-medium text-blue-600">Left (liberal)</div>
+              <div className="text-sm text-gray-600">
+                Language tends to support progressive framing
+              </div>
+            </div>
+          </div>
+
+          {/* Neutral bias */}
+          <div className="flex items-start space-x-3">
+            <div className="w-2 h-2 bg-gray-600 rounded-full mt-2 flex-shrink-0" />
+            <div>
+              <div className="font-medium text-gray-600">Neutral</div>
+              <div className="text-sm text-gray-600">Little framing detected</div>
+            </div>
+          </div>
+
+          {/* Right bias */}
+          <div className="flex items-start space-x-3">
+            <div className="w-2 h-2 bg-red-600 rounded-full mt-2 flex-shrink-0" />
+            <div>
+              <div className="font-medium text-red-600">Right (conservative)</div>
+              <div className="text-sm text-gray-600">
+                Language tends to support conservative framing
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Disclaimer */}
+        <div className="mt-4 pt-4 border-t border-gray-200">
+          <p className="text-sm text-gray-500 italic">AI estimate of framing. Use your judgment.</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/thebiaslens/src/components/analyze/BiasMeter.tsx
+++ b/app/thebiaslens/src/components/analyze/BiasMeter.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { BiasResult, BiasLabel } from '../../types/api';
+
+// Bias styling constants
+const biasTokens = {
+  trackGradient: 'linear-gradient(90deg, #b8d3f0 0%, #d9dee4 50%, #f2c5c5 100%)',
+  needleColor: {
+    Left: '#2563eb', // blue-600
+    Neutral: '#4b5563', // gray-600
+    Right: '#dc2626', // red-600
+  } satisfies Record<BiasLabel, string>,
+};
+
+interface BiasMeterProps {
+  bias: BiasResult | null;
+  className?: string;
+}
+
+export const BiasMeter: React.FC<BiasMeterProps> = ({ bias, className = '' }) => {
+  const scoreOrZero = bias?.score ?? 0;
+  const label = bias?.label ?? 'Neutral';
+  const confidence = bias?.confidence ?? 0;
+
+  // Convert score from [-1, 1] to percentage [0, 100]
+  const percent = ((scoreOrZero + 1) / 2) * 100;
+
+  return (
+    <div className={`w-full ${className}`}>
+      {/* Meter track and needle */}
+      <div className="relative">
+        {/* Track with gradient background - 12px height with rounded ends */}
+        <div
+          className="h-3 rounded-full relative"
+          style={{ background: biasTokens.trackGradient }}
+          role="meter"
+          aria-valuemin={-1}
+          aria-valuemax={1}
+          aria-valuenow={scoreOrZero}
+          aria-label="Bias from left to right"
+        >
+          {/* Needle - 2px wide vertical line with rounded caps and slight shadow */}
+          <div
+            className="absolute top-0 w-0.5 h-3 rounded-full shadow-sm"
+            style={{
+              left: `${percent}%`,
+              backgroundColor: biasTokens.needleColor[label],
+              transform: 'translateX(-50%)',
+              boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
+            }}
+          />
+        </div>
+
+        {/* Labels under the track - 12-13px medium */}
+        <div className="flex justify-between mt-2 text-xs font-medium text-gray-600">
+          <span>Left (liberal)</span>
+          <span>Neutral</span>
+          <span>Right (conservative)</span>
+        </div>
+
+        {/* Status line - 14-15px medium */}
+        <div className="mt-2 text-sm font-medium text-gray-700">
+          {bias === null ? (
+            <span>Bias: Neutral (not computed)</span>
+          ) : (
+            <span>
+              Bias: {label} ({Math.round(confidence * 100)}% confidence)
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/thebiaslens/src/components/analyze/ExtractResultCard.tsx
+++ b/app/thebiaslens/src/components/analyze/ExtractResultCard.tsx
@@ -1,33 +1,14 @@
 import React from 'react';
 import { Card, CardContent, Alert } from '@mui/material';
-import { ExtractResult, SummaryResult } from '../../types/api';
+import { ExtractResult } from '../../types/api';
 import ArticleMetadata from './ArticleMetadata';
-import SummarySection from './SummarySection';
-import ArticleTextSection from './ArticleTextSection';
 
 interface ExtractResultCardProps {
   result: ExtractResult;
-  summaryResult?: SummaryResult;
-  isSummarizing: boolean;
-  summaryError: any;
-  showFullText: boolean;
-  onToggleText: () => void;
-  onRegenerate: () => void;
   formatDate: (dateString?: string) => string | null;
-  getPreviewText: (text: string, maxLength?: number) => string;
 }
 
-const ExtractResultCard: React.FC<ExtractResultCardProps> = ({
-  result,
-  summaryResult,
-  isSummarizing,
-  summaryError,
-  showFullText,
-  onToggleText,
-  onRegenerate,
-  formatDate,
-  getPreviewText,
-}) => {
+const ExtractResultCard: React.FC<ExtractResultCardProps> = ({ result, formatDate }) => {
   return (
     <Card sx={{ mt: 3, boxShadow: 2 }}>
       <CardContent sx={{ p: 3 }}>
@@ -40,25 +21,10 @@ const ExtractResultCard: React.FC<ExtractResultCardProps> = ({
           </Alert>
         )}
         {result.extractStatus !== 'extracted' && (
-          <Alert severity="info" sx={{ mb: 3 }}>
+          <Alert severity="info" sx={{ mb: 0 }}>
             Couldn't fetch full text. You can still proceed with summary later.
           </Alert>
         )}
-
-        <SummarySection
-          result={result}
-          summaryResult={summaryResult}
-          isSummarizing={isSummarizing}
-          summaryError={summaryError}
-          onRegenerate={onRegenerate}
-        />
-
-        <ArticleTextSection
-          result={result}
-          showFullText={showFullText}
-          onToggleText={onToggleText}
-          getPreviewText={getPreviewText}
-        />
       </CardContent>
     </Card>
   );

--- a/app/thebiaslens/src/hooks/useAnalyze.ts
+++ b/app/thebiaslens/src/hooks/useAnalyze.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { get } from '../api/client';
+import { AnalyzeResult } from '../types/api';
+
+export const useAnalyze = (url: string) => {
+  return useQuery({
+    queryKey: ['analyze', url],
+    queryFn: () => get<AnalyzeResult>('/analyze/url', { url }),
+    enabled: url.trim().length >= 8, // Match useExtract pattern
+  });
+};

--- a/app/thebiaslens/src/routes/AnalyzePage.tsx
+++ b/app/thebiaslens/src/routes/AnalyzePage.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Container, Typography, Alert } from '@mui/material';
+import { Box, Container, Typography, Alert, Card, CardContent } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
-import { useExtract } from '../hooks/useExtract';
-import { useSummarize } from '../hooks/useSummarize';
+import { useAnalyze } from '../hooks/useAnalyze';
 import UrlForm from '../components/analyze/UrlForm';
-import ResultSkeleton from '../components/ResultSkeleton';
 import InputTypeSelector from '../components/analyze/InputTypeSelector';
-import ExtractResultCard from '../components/analyze/ExtractResultCard';
+import ArticleTextCard from '../components/analyze/ArticleTextCard';
+import { BiasAndSummarySection } from '../components/analyze/BiasAndSummarySection';
+import ArticleMetadata from '../components/analyze/ArticleMetadata';
 import { formatDate, getPreviewText } from '../utils/textUtils';
 
 const AnalyzePage = () => {
@@ -14,24 +14,16 @@ const AnalyzePage = () => {
   const [inputType, setInputType] = useState<'url' | 'text' | 'pdf'>('url');
   const [currentUrl, setCurrentUrl] = useState('');
   const [showFullText, setShowFullText] = useState(false);
-  const [summaryEnabled, setSummaryEnabled] = useState(false);
 
   // Check for URL parameter on component mount
   useEffect(() => {
     const urlParam = searchParams.get('url');
     if (urlParam) {
       setCurrentUrl(urlParam);
-      setSummaryEnabled(true);
     }
   }, [searchParams]);
 
-  const { data: extractResult, isLoading, error } = useExtract(currentUrl);
-  const {
-    data: summaryResult,
-    isLoading: isSummarizing,
-    error: summaryError,
-    refetch: refetchSummary,
-  } = useSummarize(extractResult?.body || '', summaryEnabled && !!extractResult?.body);
+  const { data: analyzeResult, isLoading, error } = useAnalyze(currentUrl);
 
   const handleInputTypeChange = (
     _event: React.MouseEvent<HTMLElement>,
@@ -45,7 +37,6 @@ const AnalyzePage = () => {
   const handleUrlSubmit = (url: string) => {
     setCurrentUrl(url);
     setShowFullText(false);
-    setSummaryEnabled(true);
   };
 
   const handleToggleText = () => {
@@ -78,26 +69,121 @@ const AnalyzePage = () => {
 
       {/* Results area */}
       <Box sx={{ mt: 3 }}>
-        {isLoading && <ResultSkeleton />}
+        {isLoading && (
+          <>
+            {/* Combined card skeleton for title, metadata, bias and summary */}
+            <Card sx={{ mt: 3, boxShadow: 2 }}>
+              <CardContent sx={{ p: 3 }}>
+                <div className="animate-pulse">
+                  {/* Title skeleton */}
+                  <div className="h-7 bg-gray-200 rounded w-3/4 mb-2"></div>
 
-        {error && (
-          <Alert severity="error" sx={{ mt: 2 }}>
-            Failed to extract content. Please check the URL and try again.
-          </Alert>
+                  {/* Source and metadata skeleton */}
+                  <div className="flex items-center space-x-2 mb-4">
+                    <div className="h-8 bg-blue-200 rounded w-24"></div>
+                    <div className="h-4 bg-gray-200 rounded w-20"></div>
+                    <div className="h-4 bg-gray-200 rounded w-24"></div>
+                  </div>
+
+                  {/* Divider */}
+                  <div className="border-t border-gray-200 my-3"></div>
+
+                  {/* Bias and Summary header */}
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="h-6 bg-gray-200 rounded w-40"></div>
+                    <div className="w-5 h-5 bg-gray-200 rounded-full"></div>
+                  </div>
+
+                  {/* Bias section */}
+                  <div className="mb-6">
+                    <div className="h-5 bg-gray-200 rounded w-32 mb-2"></div>
+                    <div className="h-3 bg-gray-200 rounded-full mb-2"></div>
+                    <div className="flex justify-between mb-2">
+                      <div className="h-3 bg-gray-200 rounded w-20"></div>
+                      <div className="h-3 bg-gray-200 rounded w-12"></div>
+                      <div className="h-3 bg-gray-200 rounded w-24"></div>
+                    </div>
+                  </div>
+
+                  {/* Summary section */}
+                  <div>
+                    <div className="space-y-2">
+                      <div className="h-4 bg-gray-200 rounded w-full"></div>
+                      <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+                      <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Article text skeleton */}
+            <Box sx={{ mt: 3 }}>
+              <div className="bg-white rounded-lg border border-gray-200 p-6 animate-pulse">
+                <div className="h-5 bg-gray-200 rounded w-32 mb-4"></div>
+                <div className="space-y-2">
+                  <div className="h-4 bg-gray-200 rounded w-full"></div>
+                  <div className="h-4 bg-gray-200 rounded w-full"></div>
+                  <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+                </div>
+              </div>
+            </Box>
+          </>
         )}
 
-        {extractResult && !isLoading && !error && (
-          <ExtractResultCard
-            result={extractResult}
-            summaryResult={summaryResult}
-            isSummarizing={isSummarizing}
-            summaryError={summaryError}
-            showFullText={showFullText}
-            onToggleText={handleToggleText}
-            onRegenerate={refetchSummary}
-            formatDate={formatDate}
-            getPreviewText={getPreviewText}
-          />
+        {error && (
+          <>
+            <Alert severity="error" sx={{ mt: 2 }}>
+              Failed to extract content. Please check the URL and try again.
+            </Alert>
+            {/* Show small error alert for bias and summary analysis failure */}
+            <Alert severity="warning" sx={{ mt: 2 }} variant="outlined">
+              Bias and summary analysis unavailable for this request.
+            </Alert>
+          </>
+        )}
+
+        {analyzeResult && !isLoading && !error && (
+          <>
+            {/* Single card with Title, Source, Metadata, Bias and Summary */}
+            <Card sx={{ mt: 3, boxShadow: 2 }}>
+              <CardContent sx={{ p: 3 }}>
+                <ArticleMetadata result={analyzeResult.extract} formatDate={formatDate} />
+
+                {/* Paywall and status messages */}
+                {analyzeResult.extract.paywalled && (
+                  <Alert severity="warning" sx={{ mb: 2 }}>
+                    This article appears to be behind a paywall. Content may be limited.
+                  </Alert>
+                )}
+                {analyzeResult.extract.extractStatus !== 'extracted' && (
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    Couldn't fetch full text. You can still proceed with summary later.
+                  </Alert>
+                )}
+
+                {/* Divider between metadata and bias/summary */}
+                <div className="border-t border-gray-200 my-3"></div>
+
+                <BiasAndSummarySection
+                  bias={analyzeResult.bias || null}
+                  result={analyzeResult.extract}
+                  summaryResult={analyzeResult.summary || undefined}
+                  isSummarizing={false}
+                  summaryError={null}
+                  onRegenerate={() => {}} // No regenerate for combined endpoint
+                />
+              </CardContent>
+            </Card>
+
+            {/* Article Text */}
+            <ArticleTextCard
+              result={analyzeResult.extract}
+              showFullText={showFullText}
+              onToggleText={handleToggleText}
+              getPreviewText={getPreviewText}
+            />
+          </>
         )}
       </Box>
     </Container>

--- a/app/thebiaslens/src/types/api.ts
+++ b/app/thebiaslens/src/types/api.ts
@@ -6,6 +6,15 @@ export type ArticleStub = {
   extractStatus?: 'api' | 'extracted' | 'missing';
 };
 
+export type BiasLabel = 'Left' | 'Neutral' | 'Right';
+
+export type BiasResult = {
+  label: BiasLabel;
+  confidence: number; // [0..1]
+  score: number; // [-1..1] where -1 left, 0 neutral, +1 right
+  calibrationVersion: string;
+};
+
 export type ExtractResult = {
   url: string;
   headline?: string;
@@ -28,6 +37,7 @@ export type SummaryResult = {
 export type AnalyzeResult = {
   extract: ExtractResult;
   summary?: SummaryResult | null;
+  bias?: BiasResult | null;
 };
 
 export type Paged<T> = {


### PR DESCRIPTION

- Backend: add bias to AnalyzeResult with a three-label enum and a single scalar score
- Backend: /analyze/url returns bias: null for now

- Frontend: Bias meter UI with three labels and one needle
- Frontend: Legend with short definitions and one-line disclaimer
- Frontend: Search results show “Bias: pending” pill