### PR TITLE
Sprint2.5 feat/shareable analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ TheBiasLens consists of two main components:
 - **Real-time Updates**: Live search results with loading states and error handling
 - **Unified Analysis UI**: Integrated card layout combining metadata, bias analysis, and summary
 - **Copy Functionality**: One-click copy for summaries with visual feedback
+- **Shareable Analysis Links**: Deterministic analysis ids enable clean links like `/analyze/:id?url=...`
+- **Open/Copy/Share Actions**: Open canonical article, copy app link with feedback, or share via Web Share API
+- **Canonical URL Detection**: Extracts and reports canonical URL per page metadata
+- **Sources & Citations**: Primary source plus up to 5 referenced links deduped by host
+- **UX Polishing**: Clear (X) button on URL input, subtle skeletons for actions/sources, footer disclaimer
 
 ### Planned Features 🚧
 
@@ -59,6 +64,16 @@ TheBiasLens consists of two main components:
 2. **Analyze Articles**: Click "Analyze" buttons in search results to extract and summarize content
 3. **Review Results**: View extracted article metadata, content, and AI-generated summaries
 4. **Navigate Seamlessly**: Switch between search and analysis with automatic URL parameter handling
+5. **Share Results**: Use Copy/Share actions to share a stable link to the analysis
+
+### Direct Link Formats
+
+- Analyze by URL query:
+  - `/analyze?url=<article-url>`
+- Analyze by deterministic id (clean route):
+  - `/analyze/<id>?url=<article-url>`
+
+Note: `id` is derived from the canonicalized URL (sha256→base32) and cannot be reversed; the `url` query is required to run the analysis.
 
 ## Project Structure
 
@@ -92,6 +107,9 @@ thebiaslens/
 - URL parameter handling for direct analysis links
 - Copy feedback and improved user interactions
 - Mock data fallback for development
+- Share/Copy actions for analysis links
+- Sources & Citations section on Analyze page
+- Deterministic analysis ids and canonical URL detection
 
 🚧 **In Progress**:
 
@@ -105,3 +123,7 @@ thebiaslens/
 - User authentication and preferences
 - Historical analysis and trending
 - Browser extension for real-time analysis
+
+## Disclaimer
+
+Bias and fact-check estimations are AI-generated and may not be fully accurate. This is for informational purposes only.

--- a/api/README.md
+++ b/api/README.md
@@ -60,8 +60,6 @@ SUMMARY_MAX_CHARS=600                    # Default maximum characters in summary
 
 ## Run Commands
 
-### Local Development
-
 ```bash
 # Start with auto-reload for development
 uvicorn main:app --reload
@@ -215,8 +213,11 @@ GET /analyze/url?url=https://example.com/news-article
 
 ```json
 {
+  "id": "abc123defg",
+  "canonicalUrl": "https://example.com/news-article",
   "extract": {
-    "url": "https://example.com/news-article",
+    "url": "https://example.com/news-article?utm_source=twitter",
+    "canonicalUrl": "https://example.com/news-article",
     "headline": "Article Headline",
     "source": "Source Name",
     "body": "Full article text...",
@@ -237,6 +238,34 @@ GET /analyze/url?url=https://example.com/news-article
   }
 }
 ```
+
+Fields:
+
+- `id`: Stable 10-char slug derived from the canonical URL (sha256 → base32)
+- `canonicalUrl`: Canonical URL detected from the page (`<link rel=canonical>`, `og:url`, JSON-LD),
+  falling back to normalized input URL when not present
+
+### GET `/analyze/id/{id}`
+
+Helper endpoint to address an analysis by deterministic id. Since ids are one-way hashes, provide the `url` query for verification and analysis.
+
+**Parameters:**
+
+- `id` (path): Deterministic slug produced from the canonical URL
+- `url` (query, required): Original URL; must canonicalize to the same id
+
+**Example Request:**
+
+```
+GET /analyze/id/abc123defg?url=https://example.com/news-article
+```
+
+Returns the same response shape as `/analyze/url`.
+
+Notes:
+
+- If the `url` canonicalizes to an id different from the path parameter, the API responds with `400`.
+- This provides a stable route for the frontend without a database.
 
 ## Architecture
 

--- a/api/README.md
+++ b/api/README.md
@@ -70,8 +70,6 @@ uvicorn main:app --host 127.0.0.1 --port 8000 --reload
 
 API will be available at `http://127.0.0.1:8000`
 
-### Production Deploy
-
 ```bash
 # Production server
 uvicorn main:app --host 0.0.0.0 --port $PORT
@@ -85,7 +83,7 @@ uvicorn main:app --host 0.0.0.0 --port $PORT --workers 4
 ### GET `/health`
 
 Health check endpoint for monitoring and service discovery.
-
+"url": "https://example.com/news-article",
 **Response:**
 
 ```json
@@ -114,20 +112,21 @@ GET /search?q=climate%20change&pageSize=5&cursor=1
 ```
 
 **Response:**
-
-```json
 {
-  "items": [
-    {
-      "url": "https://example.com/article",
-      "source": "Source Name",
-      "publishedAt": "2025-09-22T10:00:00Z",
-      "title": "Article Title",
-      "extractStatus": "api"
-    }
-  ],
-  "nextCursor": 2
+"items": [
+{
+"url": "https://example.com/article",
+"source": "Source Name",
+"publishedAt": "2025-09-22T10:00:00Z",
+"title": "Article Title",
+"extractStatus": "api"
 }
+],
+**Analyze by ID**: `GET /analyze/id/{id}?url=` — stable route using deterministic id (requires `url`)
+Client tip:
+
+- App link format: `/analyze/<id>?url=<encoded-url>`
+
 ```
 
 ### GET `/extract`
@@ -141,8 +140,10 @@ Extract article content from a URL using trafilatura.
 **Example Request:**
 
 ```
+
 GET /extract?url=https://example.com/news-article
-```
+
+````
 
 **Response:**
 
@@ -158,7 +159,7 @@ GET /extract?url=https://example.com/news-article
   "extractStatus": "extracted",
   "paywalled": false
 }
-```
+````
 
 **Extract Status Values:**
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -31,6 +31,7 @@ class ArticleStub(BaseModel):
 class ExtractResult(BaseModel):
     """Full article extraction result with content."""
     url: str
+    canonicalUrl: Optional[str] = None
     headline: Optional[str] = None
     source: str
     publishedAt: Optional[datetime] = None
@@ -51,6 +52,8 @@ class SummaryResult(BaseModel):
 
 class AnalyzeResult(BaseModel):
     """Combined extraction and summary result."""
+    id: str
+    canonicalUrl: str
     extract: ExtractResult
     summary: Optional[SummaryResult] = None
     bias: Optional[BiasResult] = None

--- a/api/utils/analysis_id.py
+++ b/api/utils/analysis_id.py
@@ -1,0 +1,24 @@
+import base64
+import hashlib
+
+from .normalize import canonicalize_url
+
+
+def make_analysis_id(url: str) -> str:
+    """Create a deterministic short analysis id from a URL.
+
+    Steps:
+    - Canonicalize the input URL (lower-case host, strip fragments, remove UTM/trackers)
+    - Compute SHA-256 of the canonical URL
+    - Base32-encode the digest, drop padding, lower-case, and take first 10 chars
+
+    Args:
+        url: The input URL from the user
+
+    Returns:
+        A stable, URL-safe, 10-character slug identifier.
+    """
+    canon = canonicalize_url(url)
+    digest = hashlib.sha256(canon.encode("utf-8")).digest()
+    b32 = base64.b32encode(digest).decode("ascii").rstrip("=").lower()
+    return b32[:10]

--- a/app/thebiaslens/README.md
+++ b/app/thebiaslens/README.md
@@ -14,12 +14,16 @@ React + TypeScript frontend for news search and content analysis with responsive
 - **Unified Analysis UI**: Combined card layout for metadata, bias, and summary analysis
 - **Responsive Design**: Mobile-first UI optimized for all screen sizes
 - **Navigation Flow**: Seamless transition from search results to detailed analysis
+- **Shareable Links**: Clean route `/analyze/:id?url=...` for sharing deterministic analyses
+- **Actions**: Open canonical article, Copy link with feedback, Share via Web Share API
+- **Sources & Citations**: Primary source plus up to 5 referenced links parsed from article text
 
 ### User Experience
 
 - **Loading States**: Skeleton screens and loading indicators for better perceived performance
 - **Error Handling**: User-friendly error messages and fallbacks
 - **Copy Feedback**: Visual confirmation when text is copied to clipboard
+- **Input Clear**: One-click clear (X) control inside the analysis URL input
 - **Unified Interface**: Seamless single-card experience for article analysis
 - **URL Parameter Support**: Direct links to analysis pages with pre-filled URLs
 - **Progressive Enhancement**: Works with or without JavaScript enabled
@@ -106,6 +110,8 @@ REACT_APP_API_BASE_URL=http://127.0.0.1:8000
 - `/` - Home/Search page with news article search
 - `/analyze` - Article analysis page with extraction and summarization
   - Supports `?url=` parameter for direct analysis
+- `/analyze/:id` - Shareable analysis route
+  - Requires `?url=` to run since the id is one-way and derived from the canonical URL
 - `/recents` - Recent searches (coming soon)
 - `/settings` - User preferences (coming soon)
 - `/details/:id` - Article details (coming soon)
@@ -126,6 +132,7 @@ REACT_APP_API_BASE_URL=http://127.0.0.1:8000
 2. Enters article URL manually
 3. System extracts content and generates summary
 4. Results display with copy functionality
+5. Optionally share using the clean route `/analyze/:id?url=<article-url>`
 
 ## Features in Development
 
@@ -141,6 +148,9 @@ REACT_APP_API_BASE_URL=http://127.0.0.1:8000
 - API integration with fallbacks
 - URL parameter handling for direct analysis
 - Copy-to-clipboard functionality with feedback
+- Share/Copy actions for analysis links
+- Sources & Citations section
+- Clear (X) control for analysis URL input
 - Accessibility improvements and ARIA support
 
 🚧 **Planned**:
@@ -151,6 +161,7 @@ REACT_APP_API_BASE_URL=http://127.0.0.1:8000
 - Saved searches and bookmarks
 - Advanced filtering and sorting
 - Social sharing capabilities
+  - Basic Web Share is supported; advanced share previews coming later
 
 ## Development Notes
 

--- a/app/thebiaslens/src/App.tsx
+++ b/app/thebiaslens/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 
 import { Routes, Route } from 'react-router-dom';
 import AnalyzePage from './routes/AnalyzePage';
+import AnalyzePageById from './routes/AnalyzePageById';
 import Recents from './routes/Recents';
 import Settings from './routes/Settings';
 import Details from './routes/Details';
@@ -17,6 +18,7 @@ function App() {
           <Route element={<Layout />}>
             <Route path="/" element={<Search />} />
             <Route path="/analyze" element={<AnalyzePage />} />
+            <Route path="/analyze/:id" element={<AnalyzePageById />} />
             <Route path="/recents" element={<Recents />} />
             <Route path="/settings" element={<Settings />} />
           </Route>

--- a/app/thebiaslens/src/components/analyze/SourcesSection.tsx
+++ b/app/thebiaslens/src/components/analyze/SourcesSection.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, Link as MuiLink } from '@mui/material';
+
+type Props = {
+  sourceDomain: string;
+  canonicalUrl: string;
+  bodyText?: string;
+};
+
+const urlRegex = /https?:\/\/[\w.-]+(?:\/[\w\-._~:/?#[\]@!$&'()*+,;=%]*)?/gi;
+
+const getHost = (u: string) => {
+  try {
+    return new URL(u).host.toLowerCase();
+  } catch {
+    return '';
+  }
+};
+
+const SourcesSection: React.FC<Props> = ({ sourceDomain, canonicalUrl, bodyText }) => {
+  const refs = useMemo(() => {
+    if (!bodyText) return [] as string[];
+    const found = (bodyText.match(urlRegex) || []).slice(0, 50); // cap raw finds
+    const uniqueByHost = new Map<string, string>();
+    for (const u of found) {
+      const host = getHost(u);
+      if (!host) continue;
+      if (!uniqueByHost.has(host) && !canonicalUrl.includes(u)) {
+        uniqueByHost.set(host, u);
+      }
+      if (uniqueByHost.size >= 5) break; // keep up to 5
+    }
+    return Array.from(uniqueByHost.values());
+  }, [bodyText, canonicalUrl]);
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="h6" sx={{ fontWeight: 600, mb: 1.5 }}>
+        Sources & Citations
+      </Typography>
+      <Box sx={{ fontSize: '14px', color: 'text.secondary' }}>
+        <div style={{ marginBottom: 8 }}>
+          <span style={{ color: '#666' }}>Primary:</span>{' '}
+          <MuiLink href={canonicalUrl} target="_blank" rel="noopener noreferrer" color="primary">
+            {sourceDomain}
+          </MuiLink>
+        </div>
+        {refs.length > 0 && (
+          <ul style={{ margin: 0, paddingLeft: 18, listStyle: 'disc', color: '#90a4ae' }}>
+            {refs.map((u, i) => (
+              <li key={i} style={{ marginBottom: 4 }}>
+                <MuiLink href={u} target="_blank" rel="noopener noreferrer" color="primary">
+                  {getHost(u) || u}
+                </MuiLink>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SourcesSection;

--- a/app/thebiaslens/src/components/analyze/UrlForm.tsx
+++ b/app/thebiaslens/src/components/analyze/UrlForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Box, TextField, Button } from '@mui/material';
+import { Box, TextField, Button, IconButton, InputAdornment } from '@mui/material';
+import ClearIcon from '@mui/icons-material/Clear';
 
 interface UrlFormProps {
   onSubmit: (url: string) => void;
@@ -36,6 +37,15 @@ const UrlForm: React.FC<UrlFormProps> = ({ onSubmit, isLoading, value = '' }) =>
         placeholder="https://example.com/article"
         helperText="Enter a news article URL to extract and analyze"
         variant="outlined"
+        InputProps={{
+          endAdornment: url ? (
+            <InputAdornment position="end">
+              <IconButton aria-label="Clear URL" onClick={() => setUrl('')} size="small" edge="end">
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
+        }}
       />
       <Button
         type="submit"

--- a/app/thebiaslens/src/lib/links.ts
+++ b/app/thebiaslens/src/lib/links.ts
@@ -1,0 +1,2 @@
+export const buildAnalyzeLink = (id: string, url: string) =>
+  `/analyze/${encodeURIComponent(id)}?url=${encodeURIComponent(url)}`;

--- a/app/thebiaslens/src/routes/AnalyzePageById.tsx
+++ b/app/thebiaslens/src/routes/AnalyzePageById.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import AnalyzePage from './AnalyzePage';
+import { Container, Box, Typography, TextField, Button, Alert } from '@mui/material';
+
+// A thin wrapper route that reads :id and optional ?url=
+// - If url is missing, prompt user to paste the URL
+// - If present, we just render the AnalyzePage which already reads ?url=
+const AnalyzePageById: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlParam = searchParams.get('url') || '';
+
+  const [inputUrl, setInputUrl] = useState(urlParam);
+  const [touched, setTouched] = useState(false);
+
+  useEffect(() => {
+    // Keep local input in sync with query param
+    if (urlParam && urlParam !== inputUrl) {
+      setInputUrl(urlParam);
+    }
+  }, [urlParam, inputUrl]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setTouched(true);
+    const v = inputUrl.trim();
+    if (v.length < 8) return;
+    // set ?url= and let AnalyzePage consume it
+    setSearchParams((prev) => {
+      const sp = new URLSearchParams(prev);
+      sp.set('url', v);
+      return sp;
+    });
+  };
+
+  // If we have url, render AnalyzePage (it reads ?url= itself)
+  if (urlParam) {
+    return <AnalyzePage />;
+  }
+
+  // Missing url -> prompt user
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600, mb: 1 }}>
+          Provide the article URL
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          The analysis id "{id}" requires the original URL to proceed.
+        </Typography>
+      </Box>
+
+      {touched && inputUrl.trim().length < 8 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Please paste a valid article URL.
+        </Alert>
+      )}
+
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1 }}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="https://example.com/news-article"
+          value={inputUrl}
+          onChange={(e) => setInputUrl(e.target.value)}
+        />
+        <Button type="submit" variant="contained" size="small">
+          Analyze
+        </Button>
+      </Box>
+
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="caption" color="text.secondary">
+          Note: For now, the id cannot be reversed without the URL.
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default AnalyzePageById;

--- a/app/thebiaslens/src/types/api.ts
+++ b/app/thebiaslens/src/types/api.ts
@@ -17,6 +17,7 @@ export type BiasResult = {
 
 export type ExtractResult = {
   url: string;
+  canonicalUrl?: string;
   headline?: string;
   source: string;
   publishedAt?: string;
@@ -35,6 +36,8 @@ export type SummaryResult = {
 };
 
 export type AnalyzeResult = {
+  id: string;
+  canonicalUrl: string;
   extract: ExtractResult;
   summary?: SummaryResult | null;
   bias?: BiasResult | null;


### PR DESCRIPTION
- Backend: add short-hash analysis id that deterministically maps url → id (no DB)
- Backend: /analyze/url returns id and canonicalUrl if detected
- Frontend: copy/share controls on Analyze card header
- Frontend: Sources & Citations section (domain + canonical + extracted links)
- Frontend: Footer disclaimer text
- Docs: quick note in API + App README